### PR TITLE
fix!: fix `EitherOrBoth::map_right` method signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+* ([#19](https://github.com/gamma0987/either-or-both/pull/19)): Make
+  `EitherOrBoth::map_right` signature consistent with
+  `EitherOrBoth::map_left` and general enough.
+
 ## [0.3.0] - 2025-08-30
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ name = "either-or-both"
 readme = "README.md"
 repository = "https://github.com/gamma0987/either-or-both"
 rust-version = "1.63.0"
-version = "0.3.0"
+version = "0.4.0"
 
 [features]
 default = ["either", "std"]

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.89.0"
 publish = false
 
 [dev-dependencies]
-either-or-both = { version = "0.3.0", path = ".." }
+either-or-both = { path = ".." }
 iai-callgrind = "0.16.1"
 
 [[bench]]

--- a/src/either_or_both/mod.rs
+++ b/src/either_or_both/mod.rs
@@ -1831,7 +1831,10 @@ impl<L, R> EitherOrBoth<L, R> {
     /// assert_eq!(value.map_right(map_right), EitherOrBoth::Left(1));
     /// ```
     #[inline]
-    pub fn map_right<T>(self, f: fn(R) -> T) -> EitherOrBoth<L, T> {
+    pub fn map_right<F, T>(self, f: F) -> EitherOrBoth<L, T>
+    where
+        F: FnOnce(R) -> T,
+    {
         map_each!(self; l, r => l, f(r))
     }
 


### PR DESCRIPTION
Make `EitherOrBoth::map_right` signature consistent with `EitherOrBoth::map_left` and general enough.