### PR TITLE
feat(error): implement Error for EitherOrBoth

### DIFF
--- a/src/either/traits.rs
+++ b/src/either/traits.rs
@@ -183,6 +183,7 @@ where
     L: Ord,
     R: Ord,
 {
+    // TODO: DOCS
     fn cmp(&self, other: &Self) -> Ordering {
         match (self, other) {
             (Self::Left(a), Self::Left(b)) => a.cmp(b),
@@ -198,6 +199,7 @@ where
     L: Ord,
     R: Ord,
 {
+    // TODO: DOCS
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }

--- a/src/either_or_both/traits.rs
+++ b/src/either_or_both/traits.rs
@@ -36,9 +36,11 @@ macro_rules! collect {
 }
 
 use core::cmp::Ordering;
+use core::fmt::Display;
 #[cfg(feature = "std")]
 use std::{
     collections::{HashMap, HashSet},
+    error::Error,
     vec::Vec,
 };
 
@@ -856,11 +858,186 @@ where
 // From/TryFrom/... implementations
 ////////////////////////////////////////////////////////////////////////////////
 
+#[cfg(feature = "std")]
+impl<L, R> EitherOrBoth<L, R>
+where
+    L: Error,
+    R: Error,
+{
+    /// Returns both error sources as a pair, complementing [`Error::source`]
+    ///
+    /// Since [`Error::source`] returns only the left source from the `Both` variant this
+    /// method can be used to retrieve both sources, if any.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use core::fmt::{Display, Formatter, Result};
+    /// use std::error::Error;
+    ///
+    /// use either_or_both::EitherOrBoth;
+    ///
+    /// #[derive(Debug)]
+    /// struct SuperError {};
+    /// impl Error for SuperError {};
+    /// impl Display for SuperError {
+    ///     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+    ///         f.write_str("super error")
+    ///     }
+    /// }
+    ///
+    /// #[derive(Debug)]
+    /// struct ErrLeft {
+    ///     source: Option<SuperError>,
+    /// };
+    /// impl Display for ErrLeft {
+    ///     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+    ///         f.write_str("left")
+    ///     }
+    /// }
+    /// impl Error for ErrLeft {
+    ///     fn source(&self) -> Option<&(dyn Error + 'static)> {
+    ///         self.source.as_ref().map(|e| e as &dyn Error)
+    ///     }
+    /// }
+    ///
+    /// #[derive(Debug)]
+    /// struct ErrRight {
+    ///     source: Option<SuperError>,
+    /// };
+    /// impl Display for ErrRight {
+    ///     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+    ///         f.write_str("right")
+    ///     }
+    /// }
+    /// impl Error for ErrRight {
+    ///     fn source(&self) -> Option<&(dyn Error + 'static)> {
+    ///         self.source.as_ref().map(|e| e as &dyn Error)
+    ///     }
+    /// }
+    ///
+    /// let left: EitherOrBoth<ErrLeft, ErrRight> = EitherOrBoth::Left(ErrLeft { source: None });
+    /// assert!(matches!(left.error_sources(), (None, None)));
+    ///
+    /// let right: EitherOrBoth<ErrLeft, ErrRight> = EitherOrBoth::Right(ErrRight {
+    ///     source: Some(SuperError {}),
+    /// });
+    /// assert!(matches!(right.error_sources(), (None, Some(_))));
+    ///
+    /// let both: EitherOrBoth<ErrLeft, ErrRight> = EitherOrBoth::Both(
+    ///     ErrLeft { source: None },
+    ///     ErrRight {
+    ///         source: Some(SuperError {}),
+    ///     },
+    /// );
+    /// assert!(matches!(both.error_sources(), (None, Some(_))));
+    /// ```
+    ///
+    /// [`Error::source`]: std::error::Error::source
+    pub fn error_sources(
+        &self,
+    ) -> (
+        Option<&(dyn Error + 'static)>,
+        Option<&(dyn Error + 'static)>,
+    ) {
+        match self {
+            Self::Left(l) => (l.source(), None),
+            Self::Right(r) => (None, r.source()),
+            Self::Both(l, r) => (l.source(), r.source()),
+        }
+    }
+}
+
+impl<L, R> Display for EitherOrBoth<L, R>
+where
+    L: Display,
+    R: Display,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Both(l, r) => write!(f, "{l}\n{r}"),
+            Self::Left(l) => l.fmt(f),
+            Self::Right(r) => r.fmt(f),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<L, R> Error for EitherOrBoth<L, R>
+where
+    L: Error,
+    R: Error,
+{
+    /// Returns the lower-level source of this `EitherOrBoth` error, if any
+    ///
+    /// In case there are two error sources from the `Both` variant, the left source takes
+    /// precedence. If you need both error sources use [`EitherOrBoth::error_sources`] instead.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use core::fmt::{Display, Formatter, Result};
+    /// use std::error::Error;
+    ///
+    /// use either_or_both::EitherOrBoth;
+    ///
+    /// #[derive(Debug)]
+    /// struct SuperError {}
+    /// impl Error for SuperError {}
+    /// impl Display for SuperError {
+    ///     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+    ///         f.write_str("super error")
+    ///     }
+    /// }
+    ///
+    /// #[derive(Debug)]
+    /// struct SomeError {
+    ///     source: Option<SuperError>,
+    /// };
+    /// impl Display for SomeError {
+    ///     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+    ///         f.write_str("some error")
+    ///     }
+    /// }
+    /// impl Error for SomeError {
+    ///     fn source(&self) -> Option<&(dyn Error + 'static)> {
+    ///         self.source.as_ref().map(|e| e as &dyn Error)
+    ///     }
+    /// }
+    ///
+    /// let left: EitherOrBoth<SomeError> = EitherOrBoth::Left(SomeError { source: None });
+    /// assert!(matches!(left.source(), None));
+    ///
+    /// let right: EitherOrBoth<SomeError> = EitherOrBoth::Right(SomeError {
+    ///     source: Some(SuperError {}),
+    /// });
+    /// assert!(matches!(right.source(), Some(_)));
+    ///
+    /// // Since left has no source, this method returns None even if the right error has a source
+    /// let both: EitherOrBoth<SomeError> = EitherOrBoth::Both(
+    ///     SomeError { source: None },
+    ///     SomeError {
+    ///         source: Some(SuperError {}),
+    ///     },
+    /// );
+    /// assert!(matches!(both.source(), None));
+    /// ```
+    ///
+    /// [`Error::source`]: std::error::Error::source
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Right(r) => r.source(),
+            Self::Left(l) | Self::Both(l, _) => l.source(),
+        }
+    }
+}
+
 impl<L, R> Ord for EitherOrBoth<L, R>
 where
     L: Ord,
     R: Ord,
 {
+    // TODO: DOCS
     fn cmp(&self, other: &Self) -> Ordering {
         // The implementation of Left < Both < Right
         match (self, other) {
@@ -878,6 +1055,7 @@ where
     L: Ord,
     R: Ord,
 {
+    // TODO: DOCS
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }

--- a/tests/it/either_or_both/traits.rs
+++ b/tests/it/either_or_both/traits.rs
@@ -15,6 +15,34 @@ use indexmap::{IndexMap, IndexSet};
 use rstest::rstest;
 
 #[cfg(feature = "std")]
+#[derive(Debug)]
+struct SuperError;
+#[cfg(feature = "std")]
+impl std::error::Error for SuperError {}
+#[cfg(feature = "std")]
+impl core::fmt::Display for SuperError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("super error")
+    }
+}
+
+#[cfg(feature = "std")]
+#[derive(Debug)]
+struct SomeError(Option<SuperError>);
+#[cfg(feature = "std")]
+impl core::fmt::Display for SomeError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("some error")
+    }
+}
+#[cfg(feature = "std")]
+impl std::error::Error for SomeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.0.as_ref().map(|e| e as &dyn std::error::Error)
+    }
+}
+
+#[cfg(feature = "std")]
 #[rstest]
 #[case::both_empty(vec![], Both(vec![], vec![]))]
 #[case::both_and_both(vec![Both(1, 'c'), Both(2, 'm')], Both(vec![1, 2], vec!['c', 'm']))]
@@ -361,4 +389,73 @@ fn impl_partial_ord() {
         EitherOrBoth::<u8>::Left(1u8).partial_cmp(&EitherOrBoth::Left(2)),
         Some(Ordering::Less)
     );
+}
+
+#[rstest]
+#[case::left(Left(1), "1")]
+#[case::right(Right(1), "1")]
+#[case::both(Both(1, 2), "1\n2")]
+fn impl_display(#[case] either_or_both: EitherOrBoth<u8>, #[case] expected: &str) {
+    assert_eq!(either_or_both.to_string(), expected);
+}
+
+#[cfg(feature = "std")]
+#[rstest]
+#[case::left(Left(SomeError(Some(SuperError {  }))), Some(SuperError {}))]
+#[case::right(Right(SomeError(Some(SuperError {  }))), Some(SuperError {}))]
+#[case::both_when_left_is_some_right_is_none(
+    Both(SomeError(Some(SuperError {  })), SomeError(None)),
+    Some(SuperError {})
+)]
+#[case::both_when_left_is_none_right_is_some(
+    Both(SomeError(None), SomeError(Some(SuperError {}))),
+    None
+)]
+fn impl_error(
+    #[case] either_or_both: EitherOrBoth<SomeError>,
+    #[case] expected: Option<SuperError>,
+) {
+    use std::error::Error;
+
+    match (either_or_both.source(), expected) {
+        (Some(_), None) => panic!("Expected no source but found one"),
+        (None, Some(_)) => panic!("Expected a source but found none"),
+        (None, None) | (Some(_), Some(_)) => {}
+    }
+}
+
+#[cfg(feature = "std")]
+#[rstest]
+#[case::left_no_source(Left(SomeError(None)), (None, None))]
+#[case::left_with_source(Left(SomeError(Some(SuperError {}))), (Some(SuperError {}), None))]
+#[case::right_no_source(Right(SomeError(None)), (None, None))]
+#[case::right_with_source(Right(SomeError(Some(SuperError {}))), (None, Some(SuperError {})))]
+#[case::both_no_sources(Both(SomeError(None), SomeError(None)), (None, None))]
+#[case::both_left_source_only(
+    Both(SomeError(Some(SuperError {})), SomeError(None)),
+    (Some(SuperError {}), None)
+)]
+#[case::both_right_source_only(
+    Both(SomeError(None), SomeError(Some(SuperError {}))),
+    (None, Some(SuperError {}))
+)]
+#[case::both_both_sources(
+    Both(SomeError(Some(SuperError {})), SomeError(Some(SuperError {}))),
+    (Some(SuperError {}), Some(SuperError {}))
+)]
+fn error_sources(
+    #[case] either_or_both: EitherOrBoth<SomeError>,
+    #[case] expected: (Option<SuperError>, Option<SuperError>),
+) {
+    let (left, right) = either_or_both.error_sources();
+    match (left, expected.0) {
+        (Some(_), None) => panic!("expected no left source but found one"),
+        (None, Some(_)) => panic!("expected a left source but found none"),
+        (None, None) | (Some(_), Some(_)) => {}
+    }
+    match (right, expected.1) {
+        (Some(_), None) => panic!("expected no right source but found one"),
+        (None, Some(_)) => panic!("expected a right source but found none"),
+        (None, None) | (Some(_), Some(_)) => {}
+    }
 }


### PR DESCRIPTION
## Summary

- Implement `Display` and `Error` for `EitherOrBoth`, and add an `error_sources` method
- `Display` formats `Both` as `"{left}\n{right}"`, delegates for `Left`/`Right`
- `Error::source` delegates to the inner error. `Error::source` for `Both(l, r)` yields `l.source()`, discarding the right-side source chain.
- `error_sources()` returns both sources as `(Option<&dyn Error>, Option<&dyn Error>)`, complementing `Error::source` which can only return one chain

Related #15 